### PR TITLE
Add option to set default icon if none found

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,6 +436,16 @@ version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "serde_derive"
+version = "1.0.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -614,6 +624,8 @@ dependencies = [
  "i3ipc 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_env_logger 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -675,6 +687,7 @@ dependencies = [
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 "checksum ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c92464b447c0ee8c4fb3824ecc8383b81717b9f1e74ba2e72540aef7b9f82997"
 "checksum serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)" = "9796c9b7ba2ffe7a9ce53c2287dfc48080f4b2b362fcc245a259b3a7201119dd"
+"checksum serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)" = "128f9e303a5a29922045a830221b8f78ec74a5f544944f3d5984f8ec3895ef64"
 "checksum serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)" = "051c49229f282f7c6f3813f8286cc1e3323e8051823fce42c7ea80fe13521704"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum structopt 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3fe8d3289b63ef2f196d89e7701f986583c0895e764b78f052a55b9b5d34d84a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,5 @@ structopt = "0.3.1"
 pretty_env_logger = "0.3.1"
 log = "0.4.8"
 toml = {"version" = "0.5.3", "features" = ["preserve_order"]}
+serde = "1.0"
+serde_derive = "1.0"

--- a/README.md
+++ b/README.md
@@ -63,5 +63,11 @@ The config file is located at `${XDG_CONFIG_HOME}/workstyle/config.toml`. It wil
 When an app isn't recogised in the config, `workstyle` will log the application name as an error.
 Simply add that string (case insensitive) to your config file, with an icon of your choice.
 
-Note that the crate [`find_unicode`](https://github.com/pierrechevalier83/find_unicode/) can help find a unicode character directly from the command line. It now supports all of nerdfonts unicode space.
+If no matching icon can be found in the config, a blank space will be used.
+To override this, set the default icon in the config as per below:
+```
+[other]
+default_icon = "your icon"
+```
 
+Note that the crate [`find_unicode`](https://github.com/pierrechevalier83/find_unicode/) can help find a unicode character directly from the command line. It now supports all of nerdfonts unicode space.

--- a/src/config.rs
+++ b/src/config.rs
@@ -108,10 +108,9 @@ pub(super) fn get_fallback_icon(config: &Result<PathBuf, Error>) -> String {
         .read_to_string(&mut content)
         .expect("Failed to read file");
     let config: Config = toml::from_str(&content).unwrap();
-    let icon = if let Some(other) = config.other {
+    if let Some(other) = config.other {
         other.fallback_icon
     } else {
         DEFAULT_FALLBACK_ICON.to_string()
-    };
-    icon
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,6 +7,7 @@ use std::{
 use toml::Value;
 
 const APP_NAME: &'static str = "workstyle";
+const DEFAULT_FALLBACK_ICON: &'static str = " ";
 
 fn config_file() -> Result<PathBuf, Error> {
     let mut path_to_config =
@@ -87,10 +88,17 @@ struct Config {
 
 #[derive(Debug, Deserialize)]
 struct ExtraConfig {
-    default_icon: Option<String>,
+    #[serde(default = "ExtraConfig::default_fallback_icon")]
+    fallback_icon: String,
 }
 
-pub(super) fn get_default_icon(config: &Result<PathBuf, Error>) -> String {
+impl ExtraConfig {
+  fn default_fallback_icon() -> String {
+      DEFAULT_FALLBACK_ICON.to_string()
+  }
+}
+
+pub(super) fn get_fallback_icon(config: &Result<PathBuf, Error>) -> String {
     let config_path = config.as_ref().unwrap().to_str().unwrap();
     let mut config_file = BufReader::new(
         File::open(config_path).expect(&format!("Failed to open file: {}", config_path)),
@@ -101,13 +109,9 @@ pub(super) fn get_default_icon(config: &Result<PathBuf, Error>) -> String {
         .expect("Failed to read file");
     let config: Config = toml::from_str(&content).unwrap();
     let icon = if let Some(other) = config.other {
-        if let Some(default_icon) = other.default_icon {
-            default_icon.to_string()
-        } else {
-            " ".into()
-        }
+        other.fallback_icon
     } else {
-        " ".into()
+        DEFAULT_FALLBACK_ICON.to_string()
     };
     icon
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,6 +54,7 @@ fn rename_workspaces(
     wm: &mut I3Connection,
     workspaces: &BTreeMap<String, Vec<Option<String>>>,
     icon_mappings: &[(String, String)],
+    default_icon: &String,
 ) {
     wm.get_workspaces()
         .unwrap()
@@ -61,7 +62,7 @@ fn rename_workspaces(
         .iter()
         .map(|workspace| {
             let name = workspace.name.clone();
-            let new_name = pretty_windows(&workspaces[&name], icon_mappings);
+            let new_name = pretty_windows(&workspaces[&name], icon_mappings, default_icon);
             let new_name = if new_name == "" {
                 format!("{}", workspace.num)
             } else {
@@ -74,7 +75,11 @@ fn rename_workspaces(
         })
 }
 
-fn pretty_window(window: &String, icon_mappings: &[(String, String)]) -> String {
+fn pretty_window(
+    window: &String,
+    icon_mappings: &[(String, String)],
+    default_icon: &String,
+) -> String {
     for (name, icon) in icon_mappings {
         if window.to_lowercase().contains(name) {
             return icon.clone();
@@ -82,14 +87,18 @@ fn pretty_window(window: &String, icon_mappings: &[(String, String)]) -> String 
     }
     log::error!("Couldn't identify window: {}", window);
     log::info!("Make sure to add an icon for this file in your config file!");
-    " ".into()
+    default_icon.to_string()
 }
 
-fn pretty_windows(windows: &Vec<Option<String>>, icon_mappings: &[(String, String)]) -> String {
+fn pretty_windows(
+    windows: &Vec<Option<String>>,
+    icon_mappings: &[(String, String)],
+    default_icon: &String,
+) -> String {
     let mut s = String::new();
     for window in windows {
         if let Some(window) = window {
-            s.push_str(&pretty_window(window, icon_mappings));
+            s.push_str(&pretty_window(window, icon_mappings, default_icon));
             s.push(' ');
         }
     }
@@ -104,10 +113,11 @@ fn main() {
     listener.subscribe(&[Subscription::Window]).unwrap();
     let config_file = config::generate_config_file_if_absent();
     listener.listen().for_each(|_| {
+        let default_icon = config::get_default_icon(&config_file);
         let icon_mappings = config::get_icon_mappings(&config_file);
         let tree = wm.get_tree().unwrap();
         let workspaces = workspaces_in_node(&tree);
-        rename_workspaces(&mut wm, &workspaces, &icon_mappings);
+        rename_workspaces(&mut wm, &workspaces, &icon_mappings, &default_icon);
         std::thread::sleep(std::time::Duration::from_millis(100));
     });
 }


### PR DESCRIPTION
Fixes #1 

Tried to do this without breaking the config for current users, however this means 
`ERROR workstyle::config > Expected for the map value to be a string`
shows up a lot in the log when a default-icon is set in the config.

If the icon mappings in the config could be put behind a header like `[mappings]` or something then that should prevent the error above, but that would be a breaking change for current users.