### PR TITLE
Fixed a typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Installation
 ===
 
 ```
-cargo install workstyke
+cargo install workstyle
 ```
 
 Usage


### PR DESCRIPTION
Realized there was a typo in the README in the installation instructions.
This commit fixes that.