### PR TITLE
Adding SystemD service file to enable auto start without needed to launch from sway config

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,20 @@ over
     bindsym $mod+1 workspace 1
 ```
 
+SystemD integration
+====
+
+Alternatively you can use the workstyle.service file to configure systemd to automatically start workstyle after you login
+
+Copy `workstyle.service` to `$HOME/.config/systemd/user/`
+
+and run
+
+```
+systemctl --user enable workstyle.service
+systemctl --user start workstyle.service
+```
+
 Configuration
 ===
 

--- a/workstyle.service
+++ b/workstyle.service
@@ -3,6 +3,8 @@ Description=workstyle autostart
 BindsTo=sway-session.target
 
 [Service]
+Environment="RUST_LOG=debug"
+
 ExecStart=/usr/bin/workstyle
 Restart=always
 RestartSec=3


### PR DESCRIPTION
This depends on https://github.com/alebastr/sway-systemd to provide the `sway-session.target`

Alternatively, it could be Installed using 

`
[Install]
WantedBy=graphical-session.target
`

though that would cause it to load if they user logged into another graphical desktop