### PR TITLE
remove async, remove i3ipc, refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,154 +12,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-attributes"
-version = "1.1.2"
+name = "anyhow"
+version = "1.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
-dependencies = [
- "quote",
- "syn",
-]
-
-[[package]]
-name = "async-channel"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2114d64672151c0c5eaa5e131ec84a74f06e1e559830dabba01ca30605d66319"
-dependencies = [
- "concurrent-queue",
- "event-listener",
- "futures-core",
-]
-
-[[package]]
-name = "async-executor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "871f9bb5e0a22eeb7e8cf16641feb87c9dc67032ccf8ff49e772eb9941d3a965"
-dependencies = [
- "async-task",
- "concurrent-queue",
- "fastrand",
- "futures-lite",
- "once_cell",
- "slab",
-]
-
-[[package]]
-name = "async-global-executor"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9586ec52317f36de58453159d48351bc244bc24ced3effc1fce22f3d48664af6"
-dependencies = [
- "async-channel",
- "async-executor",
- "async-io",
- "async-mutex",
- "blocking",
- "futures-lite",
- "num_cpus",
- "once_cell",
-]
-
-[[package]]
-name = "async-i3ipc"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e67ab13c5250f639802bdd0e460aa6f5cdb5849d0969d3e6c781e8d15c4b2685"
-dependencies = [
- "async-std",
- "i3ipc-types",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "async-io"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a811e6a479f2439f0c04038796b5cfb3d2ad56c230e0f2d3f7b04d68cfee607b"
-dependencies = [
- "concurrent-queue",
- "futures-lite",
- "libc",
- "log",
- "once_cell",
- "parking",
- "polling",
- "slab",
- "socket2",
- "waker-fn",
- "winapi",
-]
-
-[[package]]
-name = "async-lock"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6a8ea61bf9947a1007c5cada31e647dbc77b103c679858150003ba697ea798b"
-dependencies = [
- "event-listener",
-]
-
-[[package]]
-name = "async-mutex"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479db852db25d9dbf6204e6cb6253698f175c15726470f78af0d918e99d6156e"
-dependencies = [
- "event-listener",
-]
-
-[[package]]
-name = "async-pidfd"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12177058299bb8e3507695941b6d0d7dc0e4e6515b8bc1bf4609d9e32ef51799"
-dependencies = [
- "async-io",
- "libc",
-]
-
-[[package]]
-name = "async-std"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8056f1455169ab86dd47b47391e4ab0cbd25410a70e9fe675544f49bafaf952"
-dependencies = [
- "async-attributes",
- "async-channel",
- "async-global-executor",
- "async-io",
- "async-lock",
- "crossbeam-utils",
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-lite",
- "gloo-timers",
- "kv-log-macro",
- "log",
- "memchr",
- "num_cpus",
- "once_cell",
- "pin-project-lite",
- "pin-utils",
- "slab",
- "wasm-bindgen-futures",
-]
-
-[[package]]
-name = "async-task"
-version = "4.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91831deabf0d6d7ec49552e489aed63b7456a7a3c46cff62adad428110b0af0"
-
-[[package]]
-name = "atomic-waker"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "065374052e7df7ee4047b1160cca5e1467a12351a40b3da123c870ba0b8eda2a"
+checksum = "94a45b455c14666b85fc40a019e8ab9eb75e3a124e05494f5397122bc9eb06e0"
 
 [[package]]
 name = "atty"
@@ -174,47 +30,15 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bitflags"
-version = "1.2.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
-
-[[package]]
-name = "blocking"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046e47d4b2d391b1f6f8b407b1deb8dee56c1852ccd868becf2710f601b5f427"
-dependencies = [
- "async-channel",
- "async-task",
- "atomic-waker",
- "fastrand",
- "futures-lite",
- "once_cell",
-]
-
-[[package]]
-name = "bumpalo"
-version = "3.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
-
-[[package]]
-name = "cache-padded"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1db59621ec70f09c5e9b597b220c7a2b43611f4710dc03ceb8748637775692c"
-
-[[package]]
-name = "cc"
-version = "1.0.72"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "cfg-if"
@@ -224,9 +48,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "3.0.14"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b63edc3f163b3c71ec8aa23f9bd6070f77edbf3d1d198b164afa90ff00e4ec62"
+checksum = "e5f1fea81f183005ced9e59cdb01737ef2423956dac5a6d731b06b2ecfaa3467"
 dependencies = [
  "bitflags",
  "clap_derive",
@@ -238,82 +62,13 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.0.14"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a1132dc3944b31c20dd8b906b3a9f0a5d0243e092d59171414969657ac6aa85"
+checksum = "5fd1122e63869df2cb309f449da1ad54a7c6dfeb7c7e6ccd8e0825d9eb93bb72"
 dependencies = [
  "heck",
  "proc-macro-error",
  "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "concurrent-queue"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30ed07550be01594c6026cff2a1d7fe9c8f683caa798e12b68694ac9e88286a3"
-dependencies = [
- "cache-padded",
-]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e54ea8bc3fb1ee042f5aace6e3c6e025d3874866da222930f70ce62aceba0bfa"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
-dependencies = [
- "cfg-if",
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97242a70df9b89a65d0b6df3c4bf5b9ce03c5b7309019777fbde37e7537f8762"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
- "lazy_static",
- "memoffset",
- "scopeguard",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
-dependencies = [
- "cfg-if",
- "lazy_static",
-]
-
-[[package]]
-name = "ctor"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e98e2ad1a782e33928b96fc3948e7c355e5af34ba4de7670fe8bac2a3b2006d"
-dependencies = [
  "quote",
  "syn",
 ]
@@ -339,16 +94,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "either"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
-
-[[package]]
 name = "env_logger"
-version = "0.7.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
+checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
 dependencies = [
  "atty",
  "humantime",
@@ -358,129 +107,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "event-listener"
-version = "2.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7531096570974c3a9dcf9e4b8e1cede1ec26cf5046219fb3b9d897503b9be59"
-
-[[package]]
-name = "fastrand"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "779d043b6a0b90cc4c0ed7ee380a6504394cee7efd7db050e3774eee387324b2"
-dependencies = [
- "instant",
-]
-
-[[package]]
-name = "futures"
-version = "0.3.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28560757fe2bb34e79f907794bb6b22ae8b0e5c669b638a1132f2592b19035b4"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-channel"
-version = "0.3.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3dda0b6588335f360afc675d0564c17a77a2bda81ca178a4b6081bd86c7f0b"
-dependencies = [
- "futures-core",
- "futures-sink",
-]
-
-[[package]]
-name = "futures-core"
-version = "0.3.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c8ff0461b82559810cdccfde3215c3f373807f5e5232b71479bff7bb2583d7"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29d6d2ff5bb10fb95c85b8ce46538a2e5f5e7fdc755623a7d4529ab8a4ed9d2a"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-io"
-version = "0.3.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f9d34af5a1aac6fb380f735fe510746c38067c5bf16c7fd250280503c971b2"
-
-[[package]]
-name = "futures-lite"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694489acd39452c77daa48516b894c153f192c3578d5a839b62c58099fcbf48"
-dependencies = [
- "fastrand",
- "futures-core",
- "futures-io",
- "memchr",
- "parking",
- "pin-project-lite",
- "waker-fn",
-]
-
-[[package]]
-name = "futures-macro"
-version = "0.3.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dbd947adfffb0efc70599b3ddcf7b5597bb5fa9e245eb99f62b3a5f7bb8bd3c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "futures-sink"
-version = "0.3.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3055baccb68d74ff6480350f8d6eb8fcfa3aa11bdc1a1ae3afdd0514617d508"
-
-[[package]]
-name = "futures-task"
-version = "0.3.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ee7c6485c30167ce4dfb83ac568a849fe53274c831081476ee13e0dce1aad72"
-
-[[package]]
-name = "futures-util"
-version = "0.3.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b5cf40b47a271f77a8b1bec03ca09044d99d2372c0de244e66430761127164"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-macro",
- "futures-sink",
- "futures-task",
- "memchr",
- "pin-project-lite",
- "pin-utils",
- "slab",
-]
-
-[[package]]
 name = "getrandom"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
+checksum = "418d37c8b1d42553c93648be529cb70f920d3baf8ef469b74b9638df426e0b4c"
 dependencies = [
  "cfg-if",
  "libc",
@@ -488,23 +118,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "gloo-timers"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f16c88aa13d2656ef20d1c042086b8767bbe2bdb62526894275a1b062161b2e"
-dependencies = [
- "futures-channel",
- "futures-core",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
 name = "hashbrown"
-version = "0.9.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "heck"
@@ -514,51 +131,28 @@ checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "humantime"
-version = "1.3.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
-dependencies = [
- "quick-error",
-]
-
-[[package]]
-name = "i3ipc-types"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8426bb16ec2cd22d94f0fe1c9abd372b6974a077f5468abf197847261b2851e"
-dependencies = [
- "async-std",
- "serde",
- "serde_json",
- "serde_repr",
-]
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "indexmap"
-version = "1.6.2"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3"
+checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
 dependencies = [
  "autocfg",
  "hashbrown",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
-dependencies = [
- "cfg-if",
+ "serde",
 ]
 
 [[package]]
@@ -568,24 +162,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
-name = "js-sys"
-version = "0.3.55"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cc9ffccd38c451a86bf13657df244e9c3f37493cce8e5e21e940963777acc84"
-dependencies = [
- "wasm-bindgen",
-]
-
-[[package]]
-name = "kv-log-macro"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
-dependencies = [
- "log",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -593,9 +169,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.112"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
+checksum = "06e509672465a0504304aa87f9f176f2b2b716ed8fb105ebe5c02dc6dce96a94"
 
 [[package]]
 name = "lockfile"
@@ -613,64 +189,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
  "cfg-if",
- "value-bag",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
-
-[[package]]
-name = "memoffset"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "mio"
-version = "0.7.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
-dependencies = [
- "libc",
- "log",
- "miow",
- "ntapi",
- "winapi",
-]
-
-[[package]]
-name = "miow"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
-dependencies = [
- "winapi",
-]
-
-[[package]]
-name = "ntapi"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
-dependencies = [
- "winapi",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
-dependencies = [
- "hermit-abi",
- "libc",
-]
+checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "once_cell"
@@ -685,47 +210,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "parking"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
-
-[[package]]
-name = "pin-project-lite"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e280fbe77cc62c91527259e9442153f4688736748d24660126286329742b4c6c"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "polling"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "685404d509889fade3e86fe3a5803bca2ec09b0c0778d5ada6ec8bf7a8de5259"
-dependencies = [
- "cfg-if",
- "libc",
- "log",
- "wepoll-ffi",
- "winapi",
-]
-
-[[package]]
-name = "pretty_env_logger"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "926d36b9553851b8b0005f1275891b392ee4d2d833852c417ed025477350fb9d"
-dependencies = [
- "env_logger",
- "log",
 ]
 
 [[package]]
@@ -762,50 +246,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
-
-[[package]]
 name = "quote"
-version = "1.0.9"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
+checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
-name = "rayon"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
-dependencies = [
- "autocfg",
- "crossbeam-deque",
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
-dependencies = [
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-utils",
- "lazy_static",
- "num_cpus",
-]
-
-[[package]]
 name = "redox_syscall"
-version = "0.2.8"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "742739e41cd49414de871ea5e549afb7e2a3ac77b589bcbebe8c82fab37147fc"
+checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
 dependencies = [
  "bitflags",
 ]
@@ -839,30 +292,24 @@ checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "ryu"
-version = "1.0.5"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
-
-[[package]]
-name = "scopeguard"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
 
 [[package]]
 name = "serde"
-version = "1.0.133"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97565067517b60e2d1ea8b268e59ce036de907ac523ad83a0475da04e818989a"
+checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.133"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed201699328568d8d08208fdd080e3ff594e6c422e438b6705905da01005d537"
+checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -871,24 +318,13 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.74"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2bb9cd061c5865d345bb02ca49fcef1391741b672b54a0bf7b679badec3142"
+checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
 dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serde_repr"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98d0516900518c29efa217c298fa1f4e6c6ffc85ae29fd7f4ee48f176e1a9ed5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -911,42 +347,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "signal-hook-tokio"
-version = "0.3.1"
+name = "swayipc"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213241f76fb1e37e27de3b6aa1b068a2c333233b59cca6634f634b80a27ecf1e"
+checksum = "40cc7e2bba9f31e7c46b119d9c542496806b9114676d8f46aa5c9c950ececaec"
 dependencies = [
- "futures-core",
- "libc",
- "signal-hook",
- "tokio",
-]
-
-[[package]]
-name = "slab"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5"
-
-[[package]]
-name = "socket2"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dc90fe6c7be1a323296982db1836d1ea9e47b6839496dde9a541bc496df3516"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "swayipc-async"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f828f9cc0fe796ec7fc62264450592a65d1fac34fff1559b4fec22cc6074bcdd"
-dependencies = [
- "async-io",
- "async-pidfd",
- "futures-lite",
  "serde",
  "serde_json",
  "swayipc-types",
@@ -972,21 +377,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
-]
-
-[[package]]
-name = "sysinfo"
-version = "0.22.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f1bfab07306a27332451a662ca9c8156e3a9986f82660ba9c8e744fe8455d43"
-dependencies = [
- "cfg-if",
- "core-foundation-sys",
- "libc",
- "ntapi",
- "once_cell",
- "rayon",
- "winapi",
 ]
 
 [[package]]
@@ -1025,37 +415,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbbf1c778ec206785635ce8ad57fe52b3009ae9e0c9f574a728f3049d3e55838"
-dependencies = [
- "libc",
- "mio",
- "num_cpus",
- "pin-project-lite",
- "tokio-macros",
- "winapi",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "toml"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
- "indexmap",
  "serde",
 ]
 
@@ -1066,117 +430,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
-name = "value-bag"
-version = "1.0.0-alpha.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79923f7731dc61ebfba3633098bf3ac533bbd35ccd8c57e7088d9a5eebe0263f"
-dependencies = [
- "ctor",
- "version_check",
-]
-
-[[package]]
 name = "version_check"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
-
-[[package]]
-name = "waker-fn"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasi"
 version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
-
-[[package]]
-name = "wasm-bindgen"
-version = "0.2.78"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632f73e236b219150ea279196e54e610f5dbafa5d61786303d4da54f84e47fce"
-dependencies = [
- "cfg-if",
- "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.78"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a317bf8f9fba2476b4b2c85ef4c4af8ff39c3c7f0cdfeed4f82c34a880aa837b"
-dependencies = [
- "bumpalo",
- "lazy_static",
- "log",
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e8d7523cb1f2a4c96c1317ca690031b714a51cc14e05f712446691f413f5d39"
-dependencies = [
- "cfg-if",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.78"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d56146e7c495528bf6587663bea13a8eb588d39b36b679d83972e1a2dbbdacf9"
-dependencies = [
- "quote",
- "wasm-bindgen-macro-support",
-]
-
-[[package]]
-name = "wasm-bindgen-macro-support"
-version = "0.2.78"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7803e0eea25835f8abdc585cd3021b3deb11543c6fe226dcd30b228857c5c5ab"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-backend",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-shared"
-version = "0.2.78"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
-
-[[package]]
-name = "web-sys"
-version = "0.3.55"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38eb105f1c59d9eaa6b5cdc92b859d85b926e82cb2e0945cd0c9259faa6fe9fb"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "wepoll-ffi"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d743fdedc5c64377b5fc2bc036b01c7fd642205a0d96356034ae3404d49eb7fb"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "winapi"
@@ -1213,20 +476,17 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 name = "workstyle"
 version = "0.7.0"
 dependencies = [
- "async-i3ipc",
+ "anyhow",
  "clap",
  "dirs",
- "futures",
- "futures-util",
+ "env_logger",
+ "indexmap",
  "lockfile",
  "log",
- "pretty_env_logger",
+ "once_cell",
  "serde",
  "serde_derive",
  "signal-hook",
- "signal-hook-tokio",
- "swayipc-async",
- "sysinfo",
- "tokio",
+ "swayipc",
  "toml",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,21 +9,16 @@ homepage = "https://github.com/pierrechevalier83/workstyle"
 repository = "https://github.com/pierrechevalier83/workstyle"
 
 [dependencies]
-dirs = "3.0.2"
-clap = { version = "3.0.14", default-features = false, features = ["derive", "std"] }
-pretty_env_logger = "0.4.0"
-log = "0.4.14"
-toml = { "version" = "0.5.8", "features" = ["preserve_order"] }
+anyhow = "1.0"
+clap = { version = "3.0", default-features = false, features = ["std", "derive"] }
+dirs = "3.0"
+toml = "0.5"
 serde = "1.0"
+once_cell = "1.9"
 serde_derive = "1.0"
-lockfile = "0.3.0"
-tokio = { version = "1.15.0", features = ["macros", "rt-multi-thread"] }
-swayipc-async = "2.0.0"
-async-i3ipc = "0.5.0"
-futures-util = "0.3.19"
-signal-hook-tokio = { version = "0.3.1", features = ["futures-v0_3"] }
-signal-hook = "0.3.13"
-futures = "0.3.19"
-sysinfo = "0.22.5"
-
-[features]
+swayipc = "3.0"
+lockfile = "0.3"
+signal-hook = { version = "0.3", default-features = false, features = ["iterator"] }
+log = "0.4"
+env_logger = "0.9"
+indexmap = { version = "1.0", features = ["serde-1"] }

--- a/default_config.toml
+++ b/default_config.toml
@@ -30,5 +30,7 @@
 "music" = ""
 "disk usage" = ""
 ".pdf" = ""
+
 [other]
-"fallback_icon" = "🤨"
+fallback_icon = "🤨"
+merge = false

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,110 +1,91 @@
+use anyhow::Result;
+use indexmap::map::IndexMap;
+use serde::de::{self, Deserialize, Deserializer};
 use serde_derive::Deserialize;
-use std::path::Path;
-use std::{
-    fs::{create_dir, File},
-    io::{BufReader, Error, ErrorKind, Read, Write},
-    path::PathBuf,
-};
-use toml::Value;
+use std::fs::File;
+use std::io::{BufReader, Read, Write};
+use std::path::PathBuf;
 
-const APP_NAME: &str = "workstyle";
-const DEFAULT_FALLBACK_ICON: &str = " ";
+const DEFAULT_FALLBACK_ICON: &str = "🤨";
+const DEFAULT_CONFIG: &str = include_str!("../default_config.toml");
 
-fn config_file() -> Result<PathBuf, Error> {
-    let mut path_to_config = dirs::config_dir()
-        .ok_or_else(|| Error::new(ErrorKind::Other, "Missing default config dir"))?;
-    path_to_config.push(APP_NAME);
-    if !path_to_config.exists() {
-        create_dir(path_to_config.clone())?;
-    }
-    path_to_config.push("config.toml");
-    Ok(path_to_config)
+#[derive(Debug, Default, Clone)]
+pub struct Config {
+    pub mappings: IndexMap<String, String>,
+    pub other: Other,
 }
 
-pub(super) fn generate_config_file_if_absent() -> Result<PathBuf, Error> {
-    let config_file = config_file()?;
-    if !config_file.exists() {
-        let mut config_file = File::create(&config_file)?;
-        let content = include_bytes!("default_config.toml");
-        config_file.write_all(content)?;
-    }
-    Ok(config_file)
+#[derive(Debug, Deserialize, Default, Clone)]
+#[serde(default, deny_unknown_fields)]
+pub struct Other {
+    pub fallback_icon: Option<String>,
+    pub merge: bool,
 }
 
-// I had rather simply deserialize the map with serde, but I don't know what to deserialize into to
-// preserve ordering.
-fn try_from_toml_value(value: &Value) -> Result<Vec<(String, String)>, String> {
-    match value {
-        Value::Table(map) => Ok(map
-            .into_iter()
-            .filter_map(|(k, v)| v.as_str().map(|v| (k.clone(), v.to_string())))
-            .collect()),
-        _ => Err("Expected a map".to_string()),
-    }
-}
-
-fn get_icon_mappings_from_config(config: &Path) -> Result<Vec<(String, String)>, Error> {
-    let mut config_file = File::open(config)?;
-    let mut content = String::new();
-    config_file.read_to_string(&mut content)?;
-    try_from_toml_value(&content.parse::<toml::Value>().map_err(|e| {
-        log::error!(
-            "Error parsing configuration file.\nInvalid syntax in {:#?}.\n{}",
-            config,
-            e
-        );
-        Error::new(ErrorKind::Other, "Invalid configuration file")
-    })?)
-    .map_err(|e| {
-        log::error!("{}", e);
-        Error::new(ErrorKind::Other, "Invalid configuration file")
-    })
-}
-
-fn get_icon_mappings_from_default_config() -> Vec<(String, String)> {
-    try_from_toml_value(&String::from_utf8(include_bytes!("default_config.toml").to_vec()).expect("Expected utf-8 encoded string in default_config.toml").parse::<Value>()
-        .expect("The default config isn't user generated, so we assumed it was correct. This will teach us not to trust programmers.")).expect("Bang!")
-}
-
-pub(super) fn get_icon_mappings(config: &Result<PathBuf, Error>) -> Vec<(String, String)> {
-    if let Ok(config) = config {
-        if let Ok(content) = get_icon_mappings_from_config(config) {
-            return content;
+impl Config {
+    pub fn new() -> Result<Self> {
+        let path = Self::path()?;
+        if path.exists() {
+            let mut buf = String::new();
+            BufReader::new(File::open(path)?).read_to_string(&mut buf)?;
+            Ok(toml::from_str(&buf)?)
+        } else {
+            let mut file = File::create(path)?;
+            file.write_all(DEFAULT_CONFIG.as_bytes())?;
+            Ok(toml::from_str(DEFAULT_CONFIG)?)
         }
     }
-    get_icon_mappings_from_default_config()
-}
 
-#[derive(Debug, Deserialize)]
-struct Config {
-    other: Option<ExtraConfig>,
-}
+    pub fn fallback_icon(&self) -> &str {
+        self.other
+            .fallback_icon
+            .as_deref()
+            .unwrap_or(DEFAULT_FALLBACK_ICON)
+    }
 
-#[derive(Debug, Deserialize)]
-struct ExtraConfig {
-    #[serde(default = "ExtraConfig::default_fallback_icon")]
-    fallback_icon: String,
-}
-
-impl ExtraConfig {
-    fn default_fallback_icon() -> String {
-        DEFAULT_FALLBACK_ICON.to_string()
+    pub fn path() -> Result<PathBuf> {
+        let mut retval = match dirs::config_dir() {
+            Some(path) => path,
+            None => bail!("Could not find the configuration path"),
+        };
+        retval.push(env!("CARGO_PKG_NAME"));
+        retval.push("config.toml");
+        Ok(retval)
     }
 }
 
-pub(super) fn get_fallback_icon(config: &Result<PathBuf, Error>) -> String {
-    let config_path = config.as_ref().unwrap().to_str().unwrap();
-    let mut config_file = BufReader::new(
-        File::open(config_path).unwrap_or_else(|_| panic!("Failed to open file: {}", config_path)),
-    );
-    let mut content = String::new();
-    config_file
-        .read_to_string(&mut content)
-        .expect("Failed to read file");
-    let config: Config = toml::from_str(&content).unwrap();
-    if let Some(other) = config.other {
-        other.fallback_icon
-    } else {
-        DEFAULT_FALLBACK_ICON.to_string()
+impl<'de> Deserialize<'de> for Config {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct Visitor;
+
+        impl<'de> de::Visitor<'de> for Visitor {
+            type Value = Config;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("workstyle configuration map")
+            }
+
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: de::MapAccess<'de>,
+            {
+                let mut config = Config::default();
+                while let Some((key, value)) = map.next_entry::<String, toml::Value>()? {
+                    if key == "other" {
+                        config.other = Other::deserialize(value).unwrap();
+                    } else {
+                        config
+                            .mappings
+                            .insert(key, String::deserialize(value).unwrap());
+                    }
+                }
+                Ok(config)
+            }
+        }
+
+        deserializer.deserialize_any(Visitor)
     }
 }

--- a/src/window_manager.rs
+++ b/src/window_manager.rs
@@ -1,31 +1,20 @@
-use futures_util::stream::StreamExt;
-use std::collections::BTreeMap;
+use anyhow::Result;
+use std::collections::HashMap;
+use swayipc::{Connection, EventStream, Node, NodeType};
 
-trait Node {
-    fn is_workspace(&self) -> bool;
+trait NodeExt {
     fn is_window(&self) -> bool;
-    fn name(&self) -> Option<String>;
-    fn app_id(&self) -> Option<String>;
     fn window_properties_class(&self) -> Option<String>;
     fn windows_in_node(&self) -> Vec<Window>;
-    fn workspaces_in_node(&self) -> Result<BTreeMap<String, Vec<Window>>, &'static str>;
+    fn workspaces_in_node(&self) -> Result<HashMap<String, Vec<Window>>>;
 }
 
-impl Node for async_i3ipc::reply::Node {
-    fn is_workspace(&self) -> bool {
-        self.node_type == async_i3ipc::reply::NodeType::Workspace
-    }
+impl NodeExt for Node {
     fn is_window(&self) -> bool {
         matches!(
             self.node_type,
-            async_i3ipc::reply::NodeType::Con | async_i3ipc::reply::NodeType::FloatingCon
+            swayipc::NodeType::Con | swayipc::NodeType::FloatingCon
         )
-    }
-    fn name(&self) -> Option<String> {
-        self.name.clone()
-    }
-    fn app_id(&self) -> Option<String> {
-        None
     }
     fn window_properties_class(&self) -> Option<String> {
         self.window_properties
@@ -47,67 +36,14 @@ impl Node for async_i3ipc::reply::Node {
     }
     /// Recursively find all workspaces in this node and the list of open windows for each of these
     /// workspaces
-    fn workspaces_in_node(&self) -> Result<BTreeMap<String, Vec<Window>>, &'static str> {
-        let mut res = BTreeMap::new();
+    fn workspaces_in_node(&self) -> Result<HashMap<String, Vec<Window>>> {
+        let mut res = HashMap::new();
         for node in &self.nodes {
-            if node.is_workspace() {
+            if node.node_type == NodeType::Workspace {
                 res.insert(
-                    node.name().ok_or("Expected some node name")?,
-                    node.windows_in_node(),
-                );
-            } else {
-                let workspaces = node.workspaces_in_node()?;
-                for (k, v) in workspaces {
-                    res.insert(k, v);
-                }
-            }
-        }
-        Ok(res)
-    }
-}
-
-impl Node for swayipc_async::Node {
-    fn is_workspace(&self) -> bool {
-        self.node_type == swayipc_async::NodeType::Workspace
-    }
-    fn is_window(&self) -> bool {
-        matches!(
-            self.node_type,
-            swayipc_async::NodeType::Con | swayipc_async::NodeType::FloatingCon
-        )
-    }
-    fn name(&self) -> Option<String> {
-        self.name.clone()
-    }
-    fn app_id(&self) -> Option<String> {
-        self.app_id.clone()
-    }
-    fn window_properties_class(&self) -> Option<String> {
-        self.window_properties
-            .as_ref()
-            .and_then(|prop| prop.class.clone())
-    }
-    /// Recursively find all windows names in this node
-    fn windows_in_node(&self) -> Vec<Window> {
-        let mut res = Vec::new();
-        for node in self.nodes.iter().chain(self.floating_nodes.iter()) {
-            res.extend(node.windows_in_node());
-            if node.is_window() {
-                if let Some(window) = Window::from_node(node) {
-                    res.push(window);
-                }
-            }
-        }
-        res
-    }
-    /// Recursively find all workspaces in this node and the list of open windows for each of these
-    /// workspaces
-    fn workspaces_in_node(&self) -> Result<BTreeMap<String, Vec<Window>>, &'static str> {
-        let mut res = BTreeMap::new();
-        for node in &self.nodes {
-            if node.is_workspace() {
-                res.insert(
-                    node.name().ok_or("Expected some node name")?,
+                    node.name
+                        .clone()
+                        .ok_or(anyhow!("Expected some node name"))?,
                     node.windows_in_node(),
                 );
             } else {
@@ -129,10 +65,10 @@ pub struct Window {
 }
 
 impl Window {
-    fn from_node(node: &dyn Node) -> Option<Self> {
+    fn from_node(node: &Node) -> Option<Self> {
         if node.is_window() {
-            let name = node.name();
-            let app_id = node.app_id();
+            let name = node.name.clone();
+            let app_id = node.app_id.clone();
             let window_properties_class = node.window_properties_class();
             if name.is_some() || app_id.is_some() || window_properties_class.is_some() {
                 Some(Self {
@@ -150,52 +86,15 @@ impl Window {
     pub fn matches(&self, pattern: &str) -> bool {
         self.name
             .as_ref()
-            .map(|s| s.to_lowercase().contains(pattern))
-            .unwrap_or(false)
+            .map_or(false, |s| s.to_lowercase().contains(pattern))
             || self
                 .app_id
                 .as_ref()
-                .map(|s| s.to_lowercase().contains(pattern))
-                .unwrap_or(false)
+                .map_or(false, |s| s.to_lowercase().contains(pattern))
             || self
                 .window_properties_class
                 .as_ref()
-                .map(|s| s.to_lowercase().contains(pattern))
-                .unwrap_or(false)
-    }
-}
-
-enum Connection {
-    I3(async_i3ipc::I3),
-    Sway(swayipc_async::Connection),
-}
-
-pub enum Event {
-    I3(async_i3ipc::event::Event),
-    Sway(swayipc_async::Event),
-}
-
-pub enum EventStream {
-    I3(async_i3ipc::stream::EventStream),
-    Sway(swayipc_async::EventStream),
-}
-
-impl EventStream {
-    pub async fn next(&mut self) -> Result<Event, &'static str> {
-        match self {
-            EventStream::I3(stream) => stream
-                .next()
-                .await
-                .map(Event::I3)
-                .map_err(|_| "I3: Failed to get next window event"),
-
-            EventStream::Sway(stream) => stream
-                .next()
-                .await
-                .ok_or("Sway: unexpectedly exhausted the event stream")?
-                .map(Event::Sway)
-                .map_err(|_| "Sway: Failed to get next window event"),
-        }
+                .map_or(false, |s| s.to_lowercase().contains(pattern))
     }
 }
 
@@ -204,121 +103,22 @@ pub struct WindowManager {
 }
 
 impl WindowManager {
-    async fn connect_sway() -> Result<(Self, EventStream), &'static str> {
-        let stream = swayipc_async::Connection::new()
-            .await
-            .map_err(|_| "Couldn't connect to sway")?
-            .subscribe(&[swayipc_async::EventType::Window])
-            .await
-            .map_err(|_| "Couldn't subscribe to events of type Window with sway")?;
+    pub fn connect() -> Result<(Self, EventStream)> {
         Ok((
             Self {
-                connection: Connection::Sway(
-                    swayipc_async::Connection::new()
-                        .await
-                        .map_err(|_| "Couldn't connect to Sway")?,
-                ),
+                connection: Connection::new()?,
             },
-            EventStream::Sway(stream),
+            Connection::new()?.subscribe(&[swayipc::EventType::Window])?,
         ))
     }
-    async fn connect_i3() -> Result<(Self, EventStream), &'static str> {
-        let mut i3 = async_i3ipc::I3::connect()
-            .await
-            .map_err(|_| "Couldn't connect to I3")?;
 
-        i3.subscribe(&[async_i3ipc::event::Subscribe::Window])
-            .await
-            .map_err(|_| "Couldn't subscribe to events of type Window with I3")?;
-        let stream = i3.listen();
-        Ok((
-            Self {
-                connection: Connection::I3(
-                    async_i3ipc::I3::connect()
-                        .await
-                        .map_err(|_| "Couldn't connect to i3")?,
-                ),
-            },
-            EventStream::I3(stream),
-        ))
-    }
-    pub async fn connect() -> Result<(Self, EventStream), &'static str> {
-        use sysinfo::{ProcessExt, System, SystemExt};
-
-        let s = System::new_all();
-        let is_sway = s.processes().values().any(|x| x.name() == "sway");
-        let is_i3 = s.processes().values().any(|x| x.name() == "i3");
-        if is_sway {
-            let ret = Self::connect_sway().await?;
-            log::info!("Connected to sway");
-            Ok(ret)
-        } else if is_i3 {
-            let ret = Self::connect_i3().await?;
-            log::info!("Connected to i3");
-            Ok(ret)
-        } else {
-            log::info!("Neither sway nor i3 was running");
-            Err("Couldn't connect to sway or i3 wm")
-        }
-    }
-    pub async fn get_windows_in_each_workspace(
-        &mut self,
-    ) -> Result<BTreeMap<String, Vec<Window>>, &'static str> {
-        match &mut self.connection {
-            Connection::I3(connection) => connection
-                .get_tree()
-                .await
-                .map_err(|_| "Failed to get_tree with i3")?
-                .workspaces_in_node(),
-            Connection::Sway(connection) => connection
-                .get_tree()
-                .await
-                .map_err(|_| "Failed to get_tree with sway")?
-                .workspaces_in_node(),
-        }
+    pub fn get_windows_in_each_workspace(&mut self) -> Result<HashMap<String, Vec<Window>>> {
+        self.connection.get_tree()?.workspaces_in_node()
     }
 
-    pub async fn rename_workspaces(
-        &mut self,
-        new_names: BTreeMap<String, String>,
-    ) -> Result<(), &'static str> {
-        match &mut self.connection {
-            Connection::I3(connection) => {
-                for workspace in connection
-                    .get_workspaces()
-                    .await
-                    .map_err(|_| "Failed to get_workspaces with i3")?
-                    .iter()
-                {
-                    connection
-                        .run_command(&format!(
-                            "rename workspace \"{}\" to \"{}\"",
-                            &workspace.name,
-                            &new_names.get(&workspace.name).unwrap_or(&workspace.name)
-                        ))
-                        .await
-                        .map_err(|_| "Failed to run_command with i3")?;
-                }
-                Ok(())
-            }
-            Connection::Sway(connection) => {
-                for workspace in connection
-                    .get_workspaces()
-                    .await
-                    .map_err(|_| "Failed to get_workspaces with sway")?
-                    .iter()
-                {
-                    connection
-                        .run_command(&format!(
-                            "rename workspace \"{}\" to \"{}\"",
-                            &workspace.name,
-                            &new_names.get(&workspace.name).unwrap_or(&workspace.name)
-                        ))
-                        .await
-                        .map_err(|_| "Failed to run_command with sway")?;
-                }
-                Ok(())
-            }
-        }
+    pub fn rename_workspace(&mut self, old: &str, new: &str) -> Result<()> {
+        self.connection
+            .run_command(&format!("rename workspace \"{old}\" to \"{new}\"",))?;
+        Ok(())
     }
 }


### PR DESCRIPTION
- Binary size: 3.6M -> 2.2M (1M of which is `clap`)
- Number of threads: 10 (on my four-threads CPU) -> 2
- Memory usage: 13.2K -> 3.6K
- Number of dependencies: 151 -> 72
- Compile time: 2:10 -> 1:20
- SLOC: 534 -> 316
- New features: add `merge` configuration option to merge multiple instances of the same app into one

It should be safe to remove `i3ipc` since your PR to `swayipc` got merged. Please note that I haven't tested these changes on `i3`.

Feel free to close this PR if you still think that async is necessary in this project.