### PR TITLE
Only trigger github actions on push or PR to main

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,8 @@
-on: [push, pull_request]
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
 
 name: Rust
 


### PR DESCRIPTION
In the current state, if I want to make a PR and I push a branch to that
effect, all the CI jobs get trigered twice.

With this change, we will still test contributions at the time that
matters: when a change to main is proposed.