### PR TITLE
feat: Ability to use icons for empty workspace.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,7 +474,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "workstyle"
-version = "0.8.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,7 +474,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "workstyle"
-version = "0.9.2"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workstyle"
-version = "0.8.2"
+version = "0.9.2"
 authors = ["Pierre Chevalier <pierrechevalier83@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workstyle"
-version = "0.9.2"
+version = "0.9.0"
 authors = ["Pierre Chevalier <pierrechevalier83@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -98,4 +98,13 @@ If you prefer not to have multiple copies of the same icon when there are multip
 deduplicate_icons = true
 ```
 
+If you prefer that empty workspaces be named with an icon,
+instead of with a number, you can also specify:
+
+```toml
+[other]
+use_empty_icon = true
+empty_icon = ""
+```
+
 Note that the crate [`find_unicode`](https://github.com/pierrechevalier83/find_unicode/) can help find a unicode character directly from the command line. It now supports all of nerdfonts unicode space.

--- a/default_config.toml
+++ b/default_config.toml
@@ -34,3 +34,6 @@
 [other]
 fallback_icon = "🤨"
 deduplicate_icons = false
+
+use_empty_icon = false
+empty_icon = ""

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,6 +7,7 @@ use std::io::{BufReader, Read, Write};
 use std::path::PathBuf;
 
 const DEFAULT_FALLBACK_ICON: &str = "-";
+const DEFAULT_EMPTY_ICON: &str = "o";
 const DEFAULT_CONFIG: &str = include_str!("../default_config.toml");
 
 #[derive(Debug, Default, Clone)]
@@ -20,6 +21,8 @@ pub struct Config {
 pub struct Other {
     pub fallback_icon: Option<String>,
     pub deduplicate_icons: bool,
+    pub use_empty_icon: bool,
+    pub empty_icon: Option<String>,
 }
 
 impl Config {
@@ -44,6 +47,13 @@ impl Config {
             .fallback_icon
             .as_deref()
             .unwrap_or(DEFAULT_FALLBACK_ICON)
+    }
+    
+    pub fn empty_icon(&self) -> &str {
+        self.other
+            .empty_icon
+            .as_deref()
+            .unwrap_or(DEFAULT_EMPTY_ICON)
     }
 
     pub fn path() -> Result<PathBuf> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -48,7 +48,7 @@ impl Config {
             .as_deref()
             .unwrap_or(DEFAULT_FALLBACK_ICON)
     }
-    
+
     pub fn empty_icon(&self) -> &str {
         self.other
             .empty_icon

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,10 +37,10 @@ use window_manager::{Window, WindowManager};
 ///
 /// [other]
 /// deduplicate_icons = true
-/// 
+///
 /// If you prefer that empty workspaces be named with an icon,
 /// instead of with a number, you can also specify:
-/// 
+///
 /// [other]
 /// use_empty_icon = true
 /// empty_icon = ""
@@ -123,11 +123,8 @@ fn run() -> Result<()> {
 
     loop {
         // Wait for an OK(), which indicates an event that triggers a rename
-        match wm.wait_for_event() {
-            Err(..) => continue,
-            _ => (),
-        };
-        
+        if let Err(..) = wm.wait_for_event() { continue }
+
         // TODO: watch for changes using inotify and read the config only when needed
         let config = Config::new()?;
 
@@ -140,11 +137,12 @@ fn run() -> Result<()> {
                 .context("Unexpected workspace name")?;
             if new_name.is_empty() {
                 let empty_name = if config.other.use_empty_icon {
-                    config.empty_icon().into()
+                    config.empty_icon()
                 } else {
                     num
-                }.to_string();
-                
+                }
+                .to_string();
+
                 // Extra space matches other workspace icons.
                 wm.rename_workspace(&name, &format!("{num}: {empty_name} "))?;
             } else {

--- a/src/window_manager.rs
+++ b/src/window_manager.rs
@@ -1,8 +1,10 @@
-use log::{info, debug};
+use log::{debug, info};
 
 use anyhow::{anyhow, bail, Context, Result};
 use std::collections::BTreeMap;
-use swayipc::{Connection, EventStream, EventType, Node, NodeType, Event, WorkspaceChange, WindowChange};
+use swayipc::{
+    Connection, Event, EventStream, EventType, Node, NodeType, WindowChange, WorkspaceChange,
+};
 
 trait NodeExt {
     fn is_workspace(&self) -> bool;
@@ -128,33 +130,32 @@ fn should_rename_after_event(event: Event) -> Result<()> {
                     // at the cost of running renames more often.
                     info!("Renaming on WorkspaceEvent: {:#?}", ch);
                     Ok(())
-                },
-                ch @ _ => {
+                }
+                ch => {
                     debug!("Rejected Rename for WorkspaceEvent: {:#?}", ch);
-                    Err(anyhow!("bad_ev").context("Only certain WorkspaceChange events should trigger rename"))
-                },
+                    Err(anyhow!("bad_ev")
+                        .context("Only certain WorkspaceChange events should trigger rename"))
+                }
             }
         }
-        Event::Window(boxed_window_event) => {
-            match (*boxed_window_event).change {
-                ch @ (
-                    WindowChange::New |
-                    WindowChange::Close |
-                    WindowChange::Title |
-                    WindowChange::Move |
-                    WindowChange::Urgent |
-                    WindowChange::Mark
-                ) => {
-                    info!("Renaming on WindowEvent: {:#?}", ch);
-                    Ok(())
-                },
-                ch @ _ => {
-                    debug!("Rejected Rename for WindowEvent: {:#?}", ch);
-                    Err(anyhow!("bad_ev").context("Only certain WindowChange events should trigger rename"))
-                },
+        Event::Window(boxed_window_event) => match (*boxed_window_event).change {
+            ch @ (WindowChange::New
+            | WindowChange::Close
+            | WindowChange::Title
+            | WindowChange::Move
+            | WindowChange::Urgent
+            | WindowChange::Mark) => {
+                info!("Renaming on WindowEvent: {:#?}", ch);
+                Ok(())
             }
-        }
-        _ => Err(anyhow!("bad_ev").context("Only certain Workspace and Window *Change events trigger a rename")),
+            ch => {
+                debug!("Rejected Rename for WindowEvent: {:#?}", ch);
+                Err(anyhow!("bad_ev")
+                    .context("Only certain WindowChange events should trigger rename"))
+            }
+        },
+        _ => Err(anyhow!("bad_ev")
+            .context("Only certain Workspace and Window *Change events trigger a rename")),
     }
 }
 
@@ -194,7 +195,7 @@ impl WindowManager {
             Some(event) => {
                 // Scan the kind of event to get the relevant Result
                 should_rename_after_event(event.unwrap())
-            },
+            }
         }
     }
 }

--- a/src/window_manager.rs
+++ b/src/window_manager.rs
@@ -122,12 +122,7 @@ fn should_rename_after_event(event: Event) -> Result<()> {
     match event {
         Event::Workspace(boxed_workspace_event) => {
             match (*boxed_workspace_event).change {
-                ch @ WorkspaceChange::Focus => {
-                    // Triggering on Init triggers an extra focus after
-                    // the initial focus.
-                    // Simply running a rename on every Workspace Focus
-                    // prevents this irritating visual artifact,
-                    // at the cost of running renames more often.
+                ch @ WorkspaceChange::Init => {
                     info!("Renaming on WorkspaceEvent: {:#?}", ch);
                     Ok(())
                 }


### PR DESCRIPTION
Hello! I implemented a small feature for own use, which I hope can be of use.

# What is This?
This allows users of ex. `waybar` to use dynamic icons, while still giving empty workspaces an icon instead of a number. This is implemented by renaming new workspaces right when they are created.
This is all behind a config option; defaults remain unchanged.

Implementing this is also an optimization for the rest of the program, which no longer recalculates workspace naming on _every_ `Event::Window`. Instead, only specific `Window` (and now also `Workspace`) events will do so.

**Caveats**:
- There is a small visual artifact when opening a new workspace, when the number gets renamed to the desired icon.. Unfortunately, being a program reacting to sway events, I don't see a way to fix this.

**Future Possibilities**:
- Allowing specific icons for specific numbered (empty) workspaces wouldn't be difficult to add (the idea in #33).
- Which `*.change` types precisely should trigger workspace renaming was determined with common sense, and could do with a one-over. The relevant function is `should_rename_after_event`.

Closes #39.

Let me know if I can change anything that would help it get merged.