### PR TITLE
fix: Update Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,7 +474,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "workstyle"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "clap",


### PR DESCRIPTION
The lockfile for Cargo is outdated since ed3aab2 due to bump of Cargo.toml without an update of Cargo.lock for `0.8.2`. 