### PR TITLE
make the separator configurable

### DIFF
--- a/default_config.toml
+++ b/default_config.toml
@@ -34,3 +34,4 @@
 [other]
 fallback_icon = "🤨"
 deduplicate_icons = false
+separator = ": "

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,6 +7,7 @@ use std::io::{BufReader, Read, Write};
 use std::path::PathBuf;
 
 const DEFAULT_FALLBACK_ICON: &str = "-";
+const DEFAULT_SEPARATOR: &str = ": ";
 const DEFAULT_CONFIG: &str = include_str!("../default_config.toml");
 
 #[derive(Debug, Default, Clone)]
@@ -19,6 +20,7 @@ pub struct Config {
 #[serde(default, deny_unknown_fields)]
 pub struct Other {
     pub fallback_icon: Option<String>,
+    pub separator: Option<String>,
     pub deduplicate_icons: bool,
 }
 
@@ -45,6 +47,14 @@ impl Config {
             .as_deref()
             .unwrap_or(DEFAULT_FALLBACK_ICON)
     }
+
+    pub fn separator(&self) -> &str {
+        self.other
+            .separator
+            .as_deref()
+            .unwrap_or(DEFAULT_SEPARATOR)
+    }
+
 
     pub fn path() -> Result<PathBuf> {
         let mut user_path = dirs::config_dir().context("Could not find the configuration path")?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,18 +116,19 @@ fn run() -> Result<()> {
     loop {
         // TODO: watch for changes using inotify and read the config only when needed
         let config = Config::new()?;
+        let sep: &str = config.separator().into();
 
         let workspaces = wm.get_windows_in_each_workspace()?;
         for (name, windows) in workspaces {
             let new_name = pretty_windows(&config, &windows);
             let num = name
-                .split(':')
+                .split(sep)
                 .next()
                 .context("Unexpected workspace name")?;
             if new_name.is_empty() {
                 wm.rename_workspace(&name, num)?;
             } else {
-                wm.rename_workspace(&name, &format!("{num}: {new_name}"))?;
+                wm.rename_workspace(&name, &format!("{num}{sep}{new_name}"))?;
             }
         }
 

--- a/src/window_manager.rs
+++ b/src/window_manager.rs
@@ -133,10 +133,10 @@ pub enum WindowManager {
 
 impl WM for WindowManager {
     fn connect() -> Result<Box<Self>> {
-        if let Ok(wm) = SwayOrI3::connect() {
-            Ok(Box::new(Self::SwayOrI3(wm)))
-        } else if let Ok(wm) = Hyprland::connect() {
+        if let Ok(wm) = Hyprland::connect() {
             Ok(Box::new(Self::Hyprland(wm)))
+        } else if let Ok(wm) = SwayOrI3::connect() {
+            Ok(Box::new(Self::SwayOrI3(wm)))
         } else {
             bail!("Couldn't connect to the window manager. Only Sway, I3 and Hyprland are officially supported.")
         }


### PR DESCRIPTION
I prefer to just set it to a single space without the `:`.