### PR TITLE
make the separator configurable

### DIFF
--- a/default_config.toml
+++ b/default_config.toml
@@ -34,3 +34,4 @@
 [other]
 fallback_icon = "🤨"
 deduplicate_icons = false
+separator = ": "

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,18 +116,19 @@ fn run() -> Result<()> {
     loop {
         // TODO: watch for changes using inotify and read the config only when needed
         let config = Config::new()?;
+        let sep: &str = config.separator();
 
         let workspaces = wm.get_windows_in_each_workspace()?;
         for (name, windows) in workspaces {
             let new_name = pretty_windows(&config, &windows);
             let num = name
-                .split(':')
+                .split(sep)
                 .next()
                 .context("Unexpected workspace name")?;
             if new_name.is_empty() {
                 wm.rename_workspace(&name, num)?;
             } else {
-                wm.rename_workspace(&name, &format!("{num}: {new_name}"))?;
+                wm.rename_workspace(&name, &format!("{num}{sep}{new_name}"))?;
             }
         }
 


### PR DESCRIPTION
Allow using something like space instead of the default: space + column.

If the separator is contained in any icon or in the fallback icon, use the default separator instead and log the incident.