### PR TITLE
Release lock when receiving SIGHUP

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ use clap::{Parser, ValueEnum};
 use config::Config;
 use lockfile::Lockfile;
 use once_cell::sync::Lazy;
-use signal_hook::consts::TERM_SIGNALS;
+use signal_hook::consts::{SIGHUP, SIGINT, SIGQUIT, SIGTERM};
 use signal_hook::iterator::Signals;
 use window_manager::{Window, WindowManager, WM};
 
@@ -102,7 +102,8 @@ fn aquire_lock() {
     }
 
     // Drop the lock on exit
-    let mut signals = Signals::new(TERM_SIGNALS).expect("Failed to create signals iterator");
+    let mut signals = Signals::new([SIGTERM, SIGQUIT, SIGINT, SIGHUP])
+        .expect("Failed to create signals iterator");
     spawn(move || {
         let _ = signals.forever().next();
         drop(LOCK.lock().unwrap().take());


### PR DESCRIPTION
According to ChatGPT,
> When an application is running in a terminal and that terminal is killed, the application typically receives a SIGHUP (Signal Hang Up) signal.

> The SIGHUP signal is typically sent to a process when its controlling terminal is closed or disconnected. When a terminal is closed or disconnected, the system sends the SIGHUP signal to all processes that were associated with that terminal.

> By default, most applications will terminate when they receive a SIGHUP signal. However, some applications may be designed to handle this signal differently, for example, by ignoring it or performing some specific cleanup actions before exiting. The specific behavior of an application when it receives a SIGHUP signal may depend on how the application is designed and programmed.

And who am I to doubt our AI overlords?

Fixes issue #41