### PR TITLE
feat: do not display icon of a sticky window

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -829,7 +829,7 @@ dependencies = [
 [[package]]
 name = "swayipc"
 version = "3.0.1"
-source = "git+https://github.com/pierrechevalier83/swayipc-rs.git?branch=fix_crash_when_using_without_i3_or_sway#e8eb2d8efba285b577c5e585af203baf9096b85f"
+source = "git+https://github.com/chovanecadam/swayipc-rs.git?branch=master#bee50ead80ed5453da2c81cbdf213a25811f0a81"
 dependencies = [
  "serde",
  "serde_json",
@@ -839,7 +839,7 @@ dependencies = [
 [[package]]
 name = "swayipc-types"
 version = "1.3.0"
-source = "git+https://github.com/pierrechevalier83/swayipc-rs.git?branch=fix_crash_when_using_without_i3_or_sway#e8eb2d8efba285b577c5e585af203baf9096b85f"
+source = "git+https://github.com/chovanecadam/swayipc-rs.git?branch=master#bee50ead80ed5453da2c81cbdf213a25811f0a81"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ serde_derive = "1.0"
 lockfile = "0.3.0"
 anyhow = "1.0"
 indexmap = "1.8"
-swayipc = { git = "https://github.com/pierrechevalier83/swayipc-rs.git", branch = "fix_crash_when_using_without_i3_or_sway" }
+swayipc = { git = "https://github.com/chovanecadam/swayipc-rs.git", branch = "master" }
 
 
 once_cell = "1.9"


### PR DESCRIPTION
In i3 / Sway, it is possible to create a sticky floating window which is visible on all workspaces. In the current implementation, the icon of the sticky window is always displayed on the current workspace. I think it should be hidden, as it does not help the user when navigating between workspaces and it is not pleasant to see the icons jump around, especially with more sticky windows.

I had to fork `swayipc-rs` and apply https://github.com/JayceFayne/swayipc-rs/pull/45/commits/13b9b8fbc81df643025baaea5425b871c6442501 to support i3. Sway includes the floating information in the `note_type` property.

I tested this on Sway / i3 on Fedora 36.

I am marking this as draft as you probably want to apply https://github.com/JayceFayne/swayipc-rs/pull/45/commits/13b9b8fbc81df643025baaea5425b871c6442501 on your fork of `swayipc-rs` instead of using mine. 