### PR TITLE
only attempt renaming i3 workspaces if name has changed

### DIFF
--- a/src/window_manager.rs
+++ b/src/window_manager.rs
@@ -302,6 +302,9 @@ impl WM for SwayOrI3 {
     }
 
     fn rename_workspace(&mut self, old: &str, new: &str) -> Result<()> {
+        if old == new {
+            return Ok(());
+        }
         for result in self
             .connection
             .run_command(&format!("rename workspace \"{old}\" to \"{new}\"",))


### PR DESCRIPTION
Hi,

I've been experiencing the following issue: When using `workstyle` with a multi-screen setup, moving the mouse from another screen to the main one would sometimes change the workspace active on that screen to another one.

Steps to reproduce:
1. Have multi screen setup with default workspaces 1, 2 and 3 assigned to each (also occurs with 2 monitors I think)
2. Open firefox on center screen (workspace 1)
3. change center screen to new workspace 4
4. move mouse to other screen
5. Upon re-entering center screen, the workspace gets changed to workspace 1

My system: 
OS: Linux Mint 21
kernel: 5.15
i3 version: 4.21 (i3-gaps)

Sprinkling some debug statements across the code I can see that every time the window focus changes, all workspaces get renamed to their appropriate name depending on their contents - even if those names are already the same. The issue I have appears to be with i3ipc itself (commenting out the `run_command` code block fixes the issue), but unfortunately my understanding of rust or i3ipc is not sufficient to further debug this. I have however found that the issue also disappears when simply returning early instead of attempting to run `rename worspace <X> to <X>` in i3ipc. Which I suppose should also be more efficient, hence why I am proposing this as a solution here.

Thanks for the great tool by the way, I have really enjoyed using it on another (single-screen) setup where it works flawlessly!